### PR TITLE
Custom OAuth2 pool client scopes for OAuth2 token exchange

### DIFF
--- a/api/router/supergraph.graphql
+++ b/api/router/supergraph.graphql
@@ -55,7 +55,7 @@ type Query
   @join__type(graph: FOO)
   @join__type(graph: USERS)
 {
-  heyFoo(name: String): String @join__field(graph: FOO) @requiresScopes(scopes: [["email"]])
+  heyFoo(name: String): String @join__field(graph: FOO) @requiresScopes(scopes: [["development-default-resource-server/foo:bar"]])
   getUser(id: ID): User @join__field(graph: USERS)
   heyUser(name: String): String @join__field(graph: USERS)
 }

--- a/cdk/stacks/cognito/client.ts
+++ b/cdk/stacks/cognito/client.ts
@@ -22,16 +22,19 @@ export default class CognitoClientStack extends Stack {
       StringParameter.valueFromLookup(this, "/cognito/userPoolId"),
     );
 
-    ({ userPoolClient: this.userPoolClient } = this.createClient({
-      supportedIdentityProviders: [
-        UserPoolClientIdentityProvider.COGNITO,
-        UserPoolClientIdentityProvider.GOOGLE,
-      ],
-      userPool: this.userPool,
-    }));
+    ({ userPoolClient: this.userPoolClient } = this.createClient(
+      {
+        supportedIdentityProviders: [
+          UserPoolClientIdentityProvider.COGNITO,
+          UserPoolClientIdentityProvider.GOOGLE,
+        ],
+        userPool: this.userPool,
+      },
+      ["qux:quux"]
+    ));
   }
 
-  createClient(userPoolClientProps: UserPoolClientProps) {
-    return new ClientStack(this, this.application, userPoolClientProps);
+  createClient(userPoolClientProps: UserPoolClientProps, customScopes: string[] = []) {
+    return new ClientStack(this, this.application, userPoolClientProps, customScopes);
   }
 }

--- a/cdk/stacks/cognito/userPool.ts
+++ b/cdk/stacks/cognito/userPool.ts
@@ -28,7 +28,7 @@ export default class CognitoUserPoolStack extends Stack {
         UserPoolClientIdentityProvider.GOOGLE,
       ],
       userPool: this.userPool,
-    });
+    }, ["foo:bar"]);
 
     // NOTE: AWS-provided client doesn't accept userPool Interfaces
     // requires physical pool construct


### PR DESCRIPTION
- added custom resource server to register custom scopes to user pool client
- resource tag name + "/" + tag format required at time of OAuth2 token lease; will revisit this
- updated client spec to reflect token + resource server support; tests passing