### PR TITLE
enterprise router + Rhai example

### DIFF
--- a/api/foo/src/resolvers/foo.ts
+++ b/api/foo/src/resolvers/foo.ts
@@ -2,7 +2,7 @@ import { Resolvers } from "../types/foo";
 
 const resolvers: Resolvers = {
   Query: {
-    heyFoo: (_, { name }) => `hey ${name}!`,
+    heyFoo: (_, { name }, context) => `hey ${name}!`,
   }
 };
 

--- a/api/foo/src/schemas/foo.graphql
+++ b/api/foo/src/schemas/foo.graphql
@@ -5,5 +5,5 @@ extend schema
 )
 
 type Query  {
-    heyFoo(name: String): String @requiresScopes(scopes: [["email"]])
+    heyFoo(name: String): String @requiresScopes(scopes: [["development-default-resource-server/foo:bar"]])
 }

--- a/api/foo/src/types/foo/index.ts
+++ b/api/foo/src/types/foo/index.ts
@@ -18,7 +18,7 @@ export type Scalars = {
 
 export type Query = {
   __typename?: 'Query';
-  heyFoo: Scalars['String']['output'];
+  heyFoo?: Maybe<Scalars['String']['output']>;
 };
 
 
@@ -110,7 +110,7 @@ export type ResolversParentTypes = {
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  heyFoo?: Resolver<ResolversTypes['String'], ParentType, ContextType, Partial<QueryHeyFooArgs>>;
+  heyFoo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, Partial<QueryHeyFooArgs>>;
 };
 
 export type Resolvers<ContextType = any> = {

--- a/api/router/enterprise/claims_forwarding.rhai
+++ b/api/router/enterprise/claims_forwarding.rhai
@@ -1,0 +1,16 @@
+fn process_request(request) {
+    let claims = request.context[Router.APOLLO_AUTHENTICATION_JWT_CLAIMS];
+    if claims ==() {
+      throw #{
+        status: 401
+      };
+    }
+    // Add each claim key-value pair as a separate HTTP header.
+    // Note that that claims that are not present in the JWT will be added as empty strings.
+    let claim_names = ["username", "scope"];
+    for claim_name in claim_names {
+      let claim = claims[claim_name];
+      claim = if claim == () {""} else {claim};
+      request.subgraph.headers[claim_name] = claim;
+    }
+}

--- a/api/router/enterprise/docker-compose.yml
+++ b/api/router/enterprise/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     ports:
       - 8000:4000
     volumes:
+      - "./claims_forwarding.rhai:/dist/rhai/claims_forwarding.rhai"
+      - "./main.rhai:/dist/rhai/main.rhai"
       - "./router.yaml:/dist/config/router.yaml"
       - "../supergraph.graphql:/dist/config/supergraph.graphql"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/api/router/enterprise/main.rhai
+++ b/api/router/enterprise/main.rhai
@@ -1,0 +1,9 @@
+import "claims_forwarding" as claims_forwarding;
+
+fn subgraph_service(service, subgraph) {
+    let request_callback = |request| {
+        claims_forwarding::process_request(request);
+    };
+
+    service.map_request(request_callback);
+}

--- a/api/router/enterprise/router.yaml
+++ b/api/router/enterprise/router.yaml
@@ -6,6 +6,7 @@ authentication:
 authorization:
   preview_directives:
     enabled: true
+  require_authentication: true
 coprocessor:
   url: http://authn:3000/
   router:
@@ -17,7 +18,7 @@ headers:
   all:
     request:
       - propagate:
-          matching: authorization
+          named: "Authorization"
 health_check:
   listen: 0.0.0.0:4000
   enabled: true
@@ -25,6 +26,9 @@ homepage:
   enabled: false
 include_subgraph_errors:
   all: true
+rhai:
+  main: "main.rhai"
+  scripts: "/dist/rhai"
 sandbox:
   enabled: true
 supergraph:


### PR DESCRIPTION
- adding rhai script to pass JWT claims as headers for inspection at sub-graph level
- pass Authentication header due to not turning auth-n off at the subgraph level